### PR TITLE
Add ability to set an hackney pool name

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,12 +28,15 @@ Add to your dependencies
 
     ALGOLIA_APPLICATION_ID=YOUR_APPLICATION_ID
     ALGOLIA_API_KEY=YOUR_API_KEY
+    ALGOLIA_HACKNEY_POOL_NAME=YOUR_HACKNEY_POOL_NAME
 
 #### Using config:
 
     config :algolia,
       application_id: YOUR_APPLICATION_ID,
-      api_key: YOUR_API_KEY
+      api_key: YOUR_API_KEY,
+      hackney_pool_name: ALGOLIA_HACKNEY_POOL_NAME
+
 
 *NOTE: You must use ADMIN API_KEY instead of SEARCH API_KEY to enable write access*
 

--- a/lib/algolia.ex
+++ b/lib/algolia.ex
@@ -39,6 +39,12 @@ defmodule Algolia do
       raise MissingAPIKeyError
   end
 
+  def pool_name do
+    System.get_env("ALGOLIA_HACKNEY_POOL_NAME") ||
+      Application.get_env(:algolia, :hackney_pool_name) ||
+      :default
+  end
+
   defp host(:read, 0), do: "#{application_id()}-dsn.algolia.net"
   defp host(:write, 0), do: "#{application_id()}.algolia.net"
 
@@ -163,7 +169,8 @@ defmodule Algolia do
       path_encode_fun: &URI.encode/1,
       connect_timeout: 3_000 * (curr_retry + 1),
       recv_timeout: 30_000 * (curr_retry + 1),
-      ssl_options: [{:versions, [:"tlsv1.2"]}]
+      ssl_options: [{:versions, [:"tlsv1.2"]}],
+      pool: pool_name()
     ])
     |> case do
       {:ok, code, _headers, response} when code in 200..299 ->


### PR DESCRIPTION
We use hackney to make the http requests and the way to scale hackney is to control its connections and pools. This PR gives the ability to create set a pool name for the library to use through out its requests.

With that we can create a pool with `:hackney pool` and the request will use it. But if a pool has not been created for the first request, hackney will create it automatically with default values.

If an env or configuration is not set, it will call into the `:default` pool which is the one that hackney uses when the pool is unset.
