### PR TITLE
Fix pagination for synonyms endpoint

### DIFF
--- a/lib/algolia.ex
+++ b/lib/algolia.ex
@@ -519,8 +519,8 @@ defmodule Algolia do
         }, ...]
       }}
   """
-  def export_synonyms(index) do
-    get_all_paginated_hits(index, &search_synonyms/3)
+  def export_synonyms(index, hits_per_page \\ 100) do
+    get_all_paginated_hits(index, &search_synonyms/3, hits_per_page)
   end
 
   defp get_all_paginated_hits(index, search, hits_per_page \\ 100) do
@@ -532,9 +532,17 @@ defmodule Algolia do
 
   defp get_page_hits(index, page, hits_per_page, search) do
     case search.(index, "", page: page, hits_per_page: hits_per_page) do
-      {:ok, %{"hits" => hits, "nbPages" => pages}} when page + 1 < pages -> page_hits(hits)
-      {:ok, %{"hits" => hits}} -> page_hits(hits) ++ [:stop]
-      error -> [error, :stop]
+      {:ok, %{"hits" => hits, "nbPages" => pages}} when page + 1 < pages ->
+        page_hits(hits)
+
+      {:ok, %{"hits" => hits, "nbHits" => nbHits}} when page + 1 < nbHits / hits_per_page ->
+        page_hits(hits)
+
+      {:ok, %{"hits" => hits}} ->
+        page_hits(hits) ++ [:stop]
+
+      error ->
+        [error, :stop]
     end
   end
 

--- a/test/algolia_test.exs
+++ b/test/algolia_test.exs
@@ -379,49 +379,16 @@ defmodule AlgoliaTest do
         "type" => "synonym"
       },
       %{
-        "synonyms" => ["tiny"],
+        "synonyms" => ["short"],
         "type" => "oneWaySynonym",
-        "objectID" => "785493758483",
-        "input" => "little"
-      }
-    ]
-
-    {:ok, _} =
-      @settings_test_index
-      |> batch_synonyms(synonyms, replace_existing_synonyms: true)
-      |> wait()
-
-    hits = @settings_test_index |> export_synonyms() |> Enum.map(& &1)
-
-    for {:ok, hit} <- hits do
-      synonym = Enum.find(synonyms, &(&1["objectID"] == hit["objectID"]))
-
-      assert synonym["synonyms"] == hit["synonyms"]
-      assert synonym["type"] == hit["type"]
-      assert synonym["objectID"] == hit["objectID"]
-      assert synonym["input"] == hit["input"]
-    end
-  end
-
-  test "export the complete synonyms list" do
-    synonyms = [
-      %{
-        "objectID" => "1550092819012",
-        "synonyms" => ["big", "large", "huge"],
-        "type" => "synonym"
+        "objectID" => "785493768501",
+        "input" => "small"
       },
-      %{
-        "synonyms" => ["tiny"],
+       %{
+        "synonyms" => ["short"],
         "type" => "oneWaySynonym",
-        "objectID" => "785493758483",
-        "input" => "little"
-      },
-      %{
-        "type" => "synonym",
-        "synonyms" => [
-          "clothes",
-          "clothing"
-        ]
+        "objectID" => "785493768501",
+        "input" => "small"
       }
     ]
 

--- a/test/algolia_test.exs
+++ b/test/algolia_test.exs
@@ -403,6 +403,45 @@ defmodule AlgoliaTest do
     end
   end
 
+  test "export the complete synonyms list" do
+    synonyms = [
+      %{
+        "objectID" => "1550092819012",
+        "synonyms" => ["big", "large", "huge"],
+        "type" => "synonym"
+      },
+      %{
+        "synonyms" => ["tiny"],
+        "type" => "oneWaySynonym",
+        "objectID" => "785493758483",
+        "input" => "little"
+      },
+      %{
+        "type" => "synonym",
+        "synonyms" => [
+          "clothes",
+          "clothing"
+        ]
+      }
+    ]
+
+    {:ok, _} =
+      @settings_test_index
+      |> batch_synonyms(synonyms, replace_existing_synonyms: true)
+      |> wait()
+
+    hits = @settings_test_index |> export_synonyms(2) |> Enum.map(& &1)
+
+    for {:ok, hit} <- hits do
+      synonym = Enum.find(synonyms, &(&1["objectID"] == hit["objectID"]))
+
+      assert synonym["synonyms"] == hit["synonyms"]
+      assert synonym["type"] == hit["type"]
+      assert synonym["objectID"] == hit["objectID"]
+      assert synonym["input"] == hit["input"]
+    end
+  end
+
   test "create or update rules" do
     rules = [
       %{

--- a/test/algolia_test.exs
+++ b/test/algolia_test.exs
@@ -379,10 +379,10 @@ defmodule AlgoliaTest do
         "type" => "synonym"
       },
       %{
-        "synonyms" => ["short"],
+        "synonyms" => ["tiny"],
         "type" => "oneWaySynonym",
-        "objectID" => "785493768501",
-        "input" => "small"
+        "objectID" => "785493758483",
+        "input" => "little"
       },
        %{
         "synonyms" => ["short"],
@@ -398,6 +398,8 @@ defmodule AlgoliaTest do
       |> wait()
 
     hits = @settings_test_index |> export_synonyms(2) |> Enum.map(& &1)
+
+    assert Enum.count(synonyms) == Enum.count(hits)
 
     for {:ok, hit} <- hits do
       synonym = Enum.find(synonyms, &(&1["objectID"] == hit["objectID"]))


### PR DESCRIPTION
## Description
This PR fixes a bug in the pagination of the synonyms list returned by [synonyms/search endpoint](https://www.algolia.com/doc/rest-api/search/#search-synonyms).
This endpoint only returns the total number of hits instead of the number of pages.


## Testing
All tests run integrated to Algolia application. 
For each test, an index is created and all previous indexes removed.
The original repository has the SemaphoreCI integration, with Algolia application configured.
I already opened a PR to fix the issue there and run the suite.